### PR TITLE
feat(bootstrap): Refactor bootstrap to use importState and getState methods

### DIFF
--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -1,0 +1,14 @@
+export interface HotModuleReplacementOptions {
+  LOCALSTORAGE_KEY?: string;
+  localStorage?: boolean;
+  storeToken?: any;
+  globalDispose?: string;
+  saveState?: Function;
+  assignState?: Function;
+  data?: any;
+}
+
+export interface Store {
+  getState(): any;
+  importState(state: any): void;
+}

--- a/src/webpack-state.ts
+++ b/src/webpack-state.ts
@@ -1,17 +1,15 @@
 import {Provider, OpaqueToken, Optional, Inject} from 'angular2/core';
+import {Store} from './interfaces';
 
 export const WEBPACK_HMR = new OpaqueToken('$$AppState');
 
-export class WebpackState {
+export class WebpackState implements Store {
   private _state = {};
   private _noop = Function.prototype;
   private _states = [];
 
   constructor(@Optional() @Inject(WEBPACK_HMR) state?: any) {
-    if (state) {
-      console.log('WebpackState initial data', state);
-    }
-    this._state = state || this._state;
+    this.importState(state);
   }
 
   set(prop, value) {
@@ -39,6 +37,14 @@ export class WebpackState {
         memo[item.name] = item.getState();
         return memo;
       }, initialState);
+  }
+
+  importState(state?: any) {
+    if (state) {
+      console.log('WebpackState initial data', state)
+    }
+
+    this._state = state || this._state;
   }
 
   toJSON() {


### PR DESCRIPTION
Introduces a `Store` interface. Importing state and saving state happens automatically for the user. This change makes it easier to connect other state management libraries to angular2-hmr (like @ngrx/store)